### PR TITLE
fix: change route to docs/api/json

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,7 @@ use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(config('scramble.middleware', [RestrictedDocsAccess::class]))->group(function () {
-    Route::get('docs/api.json', function (Dedoc\Scramble\Generator $generator) {
+    Route::get('docs/api/json', function (Dedoc\Scramble\Generator $generator) {
         return $generator();
     })->name('scramble.docs.index');
 


### PR DESCRIPTION
Because docs/api.json conflicts with nginx static file sharing